### PR TITLE
A patch to fix `origin` problems due to float rounding

### DIFF
--- a/wigner_time/internal/origin.py
+++ b/wigner_time/internal/origin.py
@@ -215,7 +215,7 @@ def find(
                 t,
                 _previous_vt(
                     *([timeline, "value"] + _to_col_var(timeline, s2)),
-                    time__max=t + time__max__relative,
+                    time__max=t + wt_config.TIME_RESOLUTION + time__max__relative,
                 ),
             ]
 


### PR DESCRIPTION
To allow for adding functional timelines (e.g. ramps) in arbitrary places, the existing timeline is filtered to exclude everything after a certain point in time.

Unfortunately, floating point rounding led to the last point being excluded in some, difficult to predict, circumstances. To fix this, the time resolution of the project is added to the filter when assigning the origin.